### PR TITLE
u3d 2020 fixes

### DIFF
--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -27,6 +27,7 @@ require 'fileutils'
 module U3d
   UNITY_DIR_CHECK = /Unity_\d+\.\d+\.\d+[a-z]\d+/
   UNITY_DIR_CHECK_LINUX = /unity-editor-\d+\.\d+\.\d+[a-z]\d+\z/
+  #Linux unity_builtin_extra seek position for version
   UNITY_VERSION_LINUX_POS_LE_2019 = 20
   UNITY_VERSION_LINUX_POS_GT_2019 = 48
   U3D_DO_NOT_MOVE = ".u3d_do_not_move".freeze

--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -27,6 +27,8 @@ require 'fileutils'
 module U3d
   UNITY_DIR_CHECK = /Unity_\d+\.\d+\.\d+[a-z]\d+/
   UNITY_DIR_CHECK_LINUX = /unity-editor-\d+\.\d+\.\d+[a-z]\d+\z/
+  UNITY_VERSION_LINUX_POS_LE_2019 = 20
+  UNITY_VERSION_LINUX_POS_GT_2019 = 48
   U3D_DO_NOT_MOVE = ".u3d_do_not_move".freeze
 
   class Installation
@@ -142,7 +144,15 @@ module U3d
   class InstallationUtils
     def self.read_version_from_unity_builtin_extra(file)
       File.open(file, "rb") do |f|
-        f.seek(20)
+        # Check if it is version lower or equal to 2019
+        seek_pos = UNITY_VERSION_LINUX_POS_LE_2019
+        f.seek(seek_pos)
+        z = f.read(1)
+        if z == "\x00"
+          # Version is greater than 2019
+          seek_pos = UNITY_VERSION_LINUX_POS_GT_2019
+        end
+        f.seek(seek_pos)
         s = ""
         while (c = f.read(1))
           break if c == "\x00"

--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -27,7 +27,7 @@ require 'fileutils'
 module U3d
   UNITY_DIR_CHECK = /Unity_\d+\.\d+\.\d+[a-z]\d+/
   UNITY_DIR_CHECK_LINUX = /unity-editor-\d+\.\d+\.\d+[a-z]\d+\z/
-  #Linux unity_builtin_extra seek position for version
+  # Linux unity_builtin_extra seek position for version
   UNITY_VERSION_LINUX_POS_LE_2019 = 20
   UNITY_VERSION_LINUX_POS_GT_2019 = 48
   U3D_DO_NOT_MOVE = ".u3d_do_not_move".freeze


### PR DESCRIPTION
Merging in: https://github.com/DragonBox/u3d/pull/410 2020 fix into our version

This pull request solves the error when installing in Linux a Unity version 2020. It seems that untill Unity 2019, the unity_builtin_extra file has the string version coded at byte position 20. In 2020 the string version is coded from byte position 48. It has been coded a check for trying reading what it is expected in 2019 and if it is "\x00" set the seek position for 2020.